### PR TITLE
add allium connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ v3/data/pool_initialize_events
 v3/data/pool_mint_burn_events
 v3/data/pool_swap_events
 v3/data/test/*
+v3/secrets.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -11,8 +11,43 @@
 
 ### GIF created using v3-polars
 ![](./assets/animation.gif)
-### Simple examples
 
+### Data Providers
+If you are an academic writing a paper, feel free to reach out to <a href="https://twitter.com/AustinAdams10">Austin</a>
+
+#### Allium
+The wonderful folks at <a href ="https://allium.so/">Allium</a> have integrated with v3-polars as part of their <a href="https://x.com/UniswapFND/status/1776002168681529549">DEX Analytics Portal grant</a>
+
+Please create a `secrets.json` and place it inside v3/ with the formatting below.
+
+To generate the required data
+
+1. Login to app.allium.so and create an explorer query
+2. Place only {{query_text}} in the query
+3. Click "save" on the top right, then "export to api"
+4. Here, you will get the query id and api key
+5. Place these into the secrets.json file
+
+```python
+{'allium_query_id': "",
+'allium_api_key': ""}
+```
+
+#### Google BigQuery
+To use the GBQ database, you need to be auth'd with Uniswap Labs backend. 
+Likely, if you don't know how to do this, then you should use another provider.
+
+However, if you think you should be auth'd and are not, run the code below
+
+```bash
+gcloud auth login
+```
+
+#### Your provider
+Create a new connector in v3/helpers/connectors using template.py.
+Integrate your connector into data_update.py under update_tables and make a PR!
+
+### Simple examples
 
 Pull and then read all ETH/USDC swaps on Arbitrum
 ```python

--- a/v3/helpers/connectors/__init__.py
+++ b/v3/helpers/connectors/__init__.py
@@ -1,1 +1,2 @@
 from .gbq import *
+from .allium import *

--- a/v3/helpers/connectors/allium.py
+++ b/v3/helpers/connectors/allium.py
@@ -3,8 +3,9 @@ import requests
 
 
 class allium:
-    def __init__(self):
-        pass
+    def __init__(self, allium_query_id, allium_api_key):
+        self.allium_query_id = allium_query_id
+        self.allium_api_key = allium_api_key
 
     def get_remote_table(self, table, chain):
 
@@ -199,12 +200,10 @@ class allium:
             raise ValueError("Missing table definition")
 
     def execute(self, q):
-        allium_query_id = ""
-        allium_api_key = ""
         response = requests.post(
-            f"https://api.allium.so/api/v1/explorer/queries/{allium_query_id}/run",
+            f"https://api.allium.so/api/v1/explorer/queries/{self.allium_query_id}/run",
             json={"query_text":q},
-            headers={"X-API-Key": allium_api_key},
+            headers={"X-API-Key": self.allium_api_key},
             timeout=240
         )
 

--- a/v3/helpers/connectors/allium.py
+++ b/v3/helpers/connectors/allium.py
@@ -41,7 +41,6 @@ class allium:
                 from {allium_chain_name}.dex.pools
                 where 1=1
                     and protocol='uniswap_v3'
-                    and block_timestamp<='2023-01-01'
             )
             """
         elif table == "pool_swap_events":
@@ -72,7 +71,6 @@ class allium:
                 where 1=1
                     and t1.event='swap'
                     and t1.protocol='uniswap_v3'
-                    and t1.block_timestamp<='2023-01-01'
             )
             """
         elif table == "pool_mint_burn_events":
@@ -103,7 +101,6 @@ class allium:
                 inner join {allium_chain_name}.raw.transactions t2 on t1.transaction_hash=t2.hash and t1.block_timestamp=t2.block_timestamp
                 where 1=1
                     and protocol='uniswap_v3'
-                    and t1.block_timestamp<='2023-01-01'
                     and event in ('mint', 'burn')
             )
             """
@@ -128,7 +125,6 @@ class allium:
                 inner join {allium_chain_name}.raw.transactions t2 on t1.transaction_hash=t2.hash and t1.block_timestamp=t2.block_timestamp
                 where 1=1
                     and t1.topic0='0x98636036cb66a9c19a37435efc1e90142190214e8abeb821bdba3f2990dd4c95'
-                    and t1.block_timestamp<='2023-01-01'
             )
             """
         else:

--- a/v3/helpers/connectors/allium.py
+++ b/v3/helpers/connectors/allium.py
@@ -1,0 +1,227 @@
+import polars as pl
+import requests
+
+
+class allium:
+    def __init__(self):
+        pass
+
+    def get_remote_table(self, table, chain):
+
+        # which chains are layer 2s (to get the l1 fee)
+        layer_2s = ["base", "arbitrum", "optimism"]
+        
+        # translate uniswap chain names to allium chain names
+        uniswap_to_allium_name_mapping = {
+            "ethereum": "ethereum",
+            "base": "base",
+            "arbitrum": "arbitrum",
+            "optimism": "optimism",
+            "polygon": "polygon",
+        }
+        allium_chain_name = uniswap_to_allium_name_mapping.get(chain, None)
+        if allium_chain_name is None:
+            raise ValueError(f"Chain {chain} not supported in the allium adapter, please update uniswap_to_allium_name_mapping.")
+
+        if table == "factory_pool_created":
+            query = f"""
+            (
+                select 
+                    '{chain}' as "chain_name",
+                    block_timestamp as "block_timestamp",
+                    block_number as "block_number",
+                    transaction_hash as "transaction_hash",
+                    log_index as "log_index",
+                    token0_address as "token0",
+                    token1_address as "token1",
+                    fee as "fee",
+                    tick_spacing as "tick_spacing", -- will be renamed to camel case
+                    liquidity_pool_address as "pool"
+                from {allium_chain_name}.dex.pools
+                where 1=1
+                    and protocol='uniswap_v3'
+                    and block_timestamp<='2023-01-01'
+            )
+            """
+        elif table == "pool_swap_events":
+            query = f"""
+            (
+                select 
+                    '{chain}' as "chain_name",
+                    t1.liquidity_pool_address as "address",
+                    t1.block_timestamp as "block_timestamp",
+                    t1.block_number as "block_number",
+                    t1.transaction_hash as "transaction_hash",
+                    t1.log_index as "log_index",
+                    t1.sender_address as "sender",
+                    t1.to_address as "recipient",
+                    t1.token0_amount as "amount0",
+                    t1.token1_amount as "amount1",
+                    t1.sqrt_price_x96 as "sqrt_price_x96", -- will be renamed to camel case
+                    t1.liquidity as "liquidity",
+                    t1.tick as "tick",
+                    t1.transaction_to_address as "to_address",
+                    t1.transaction_from_address as "from_address",
+                    t2.transaction_index as "transaction_index",
+                    t2.gas_price as "gas_price",
+                    t2.gas as "gas_used",
+                    {'null' if allium_chain_name not in layer_2s else 't2.receipt_l1_fee'} as "l1_fee"
+                from {allium_chain_name}.dex.events t1
+                inner join {allium_chain_name}.raw.transactions t2 on t1.transaction_hash=t2.hash and t1.block_timestamp=t2.block_timestamp
+                where 1=1
+                    and t1.event='swap'
+                    and t1.protocol='uniswap_v3'
+                    and t1.block_timestamp<='2023-01-01'
+            )
+            """
+        elif table == "pool_mint_burn_events":
+            query = f"""
+            (
+                select 
+                    '{chain}' as "chain_name",
+                    t1.liquidity_pool_address as "address",
+                    t1.block_timestamp as "block_timestamp",
+                    t1.block_hash as "block_hash",
+                    t1.block_number as "block_number",
+                    t1.transaction_hash as "transaction_hash",
+                    t1.log_index as "log_index",
+                    t1.liquidity as "amount",
+                    t1.token0_amount as "amount0",
+                    t1.token1_amount as "amount1",
+                    t1.to_address as "owner",
+                    t1.tick_lower as "tick_lower",
+                    t1.tick_upper as "tick_upper",
+                    case when t1.event='mint' then 1 else -1 end as "type_of_event",
+                    t1.transaction_to_address as "to_address",
+                    t1.transaction_from_address as "from_address",
+                    t2.transaction_index as "transaction_index",
+                    t2.gas_price as "gas_price",
+                    t2.gas as "gas_used",
+                    {'null' if allium_chain_name not in layer_2s else 't2.receipt_l1_fee'} as "l1_fee"
+                from {allium_chain_name}.dex.events t1
+                inner join {allium_chain_name}.raw.transactions t2 on t1.transaction_hash=t2.hash and t1.block_timestamp=t2.block_timestamp
+                where 1=1
+                    and protocol='uniswap_v3'
+                    and t1.block_timestamp<='2023-01-01'
+                    and event in ('mint', 'burn')
+            )
+            """
+        elif table == "pool_initialize_events":
+            query = f"""
+            (
+                select
+                    '{chain}' as "chain_name",
+                    t1.address as "address",
+                    t1.block_timestamp as "block_timestamp",
+                    t1.block_number as "block_number",
+                    t1.transaction_hash as "transaction_hash",
+                    t1.log_index as "log_index",
+                    t1.params['sqrtPriceX96']::varchar as "sqrt_price_x96", -- will be renamed to camel case    
+                    t1.params['tick']::varchar as "tick",
+                    t1.transaction_to_address as "to_address",
+                    t1.transaction_from_address as "from_address",
+                    t1.transaction_index as "transaction_index",
+                    t2.gas_price as "gas_price",
+                    t2.gas as "gas_used"
+                from {allium_chain_name}.decoded.logs t1
+                inner join {allium_chain_name}.raw.transactions t2 on t1.transaction_hash=t2.hash and t1.block_timestamp=t2.block_timestamp
+                where 1=1
+                    and t1.topic0='0x98636036cb66a9c19a37435efc1e90142190214e8abeb821bdba3f2990dd4c95'
+                    and t1.block_timestamp<='2023-01-01'
+            )
+            """
+        else:
+            raise ValueError(f"Table {table} not recognized.")
+        return query
+
+    def minMax(self, *args):
+        """
+        We want to find the bounds of the remote database
+        """
+        table, chain = args
+        table = self.get_remote_table(table, chain)
+
+        q = f"""select min("block_number") as min_block,
+                   max("block_number") as max_block,
+                   FROM {table}
+             """
+
+        return q
+
+    def findSegment(self, *args):
+        """
+        We want to find the smallest block such that we are pulling
+        around the tgt_max_rows number of rows from GBQ
+        """
+        table, max_block, min_block, chain, tgt_max_rows = args
+        table = self.get_remote_table(table, chain)
+
+        q = f"""select max("block_number")
+                from (
+                    select * 
+                    from (
+                        select "block_number"
+                        FROM {table}
+                        where 1=1
+                        and "block_number" >= {min_block}
+                        and "block_number" <= {max_block}
+                        order by "block_timestamp" asc
+                    ) limit {tgt_max_rows}
+                )
+            """
+
+        return q
+
+    def readRemote(self, *args):
+        """
+        Pull from internal GBQ data lake
+        """
+        table, max_block_of_segment, min_block_of_segment, chain = args
+        table = self.get_remote_table(table, chain)
+
+        q = f"""select * 
+            FROM {table}
+            where 1=1
+            AND "block_number" <= {max_block_of_segment}
+            AND "block_number" >= {min_block_of_segment}
+            """
+
+        return q
+
+    def get_template(self, query_type, *args):
+        if query_type == "minMax":
+            return self.minMax(*args)
+        elif query_type == "findSegment":
+            return self.findSegment(*args)
+        elif query_type == "read":
+            return self.readRemote(*args)
+        else:
+            raise ValueError("Missing table definition")
+
+    def execute(self, q):
+        allium_query_id = ""
+        allium_api_key = ""
+        response = requests.post(
+            f"https://api.allium.so/api/v1/explorer/queries/{allium_query_id}/run",
+            json={"query_text":q},
+            headers={"X-API-Key": allium_api_key},
+            timeout=240
+        )
+
+        # polars from dict
+        df = pl.DataFrame(response.json()['data'])
+
+        # api doesn't deal with camel case out of the box
+        column_renames = {"tick_spacing": "tickSpacing", "sqrt_price_x96": "sqrtPriceX96"}
+        for original, new in column_renames.items():
+            if original in df.columns:
+                df = df.rename({original: new})
+
+        # convert block_timestamp from string like '2024-04-02 12:21:33' to datetime
+        if "block_timestamp" in df.columns:
+            df = df.with_columns(df["block_timestamp"].str.to_datetime().dt.replace_time_zone("UTC"))
+
+        if len(df)>=100_000:
+            raise Exception("Tried to fetch please fetch at most 100,000 rows at a time")
+
+        return df

--- a/v3/helpers/data_update.py
+++ b/v3/helpers/data_update.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta, datetime, timezone
 from .connectors import allium, gbq
 from .test_helpers import *
 from pathlib import Path
+import json
 
 gcp_locked = True
 try:
@@ -269,14 +270,6 @@ def _update_tables(pool, tables=[], test_mode=False):
             print("Nothing to update")
 
 
-def update_tables_cryo(pool, tables=[]):
-    """
-    sad
-    """
-    # TODO
-    raise NotImplementedError("Cryo is not yet implimented")
-
-
 def update_tables(pool, update_from, tables=[], test_mode=False):
     if update_from == "gcp":
         assert not gcp_locked, "GCP could not be imported"
@@ -284,10 +277,18 @@ def update_tables(pool, update_from, tables=[], test_mode=False):
         _update_tables(pool, tables, test_mode)
 
     if update_from == "allium":
-        pool.connector = allium()
+        assert pool.tgt_max_rows <= 100_000, "Attempting to pull too many rows"
+        
+        main = str(Path(f"{pool.data_path}/..").resolve())
+        with open(f"{main}/secrets.json", "r") as f:
+            secrets = json.load(f)
+
+        pool.connector = allium(secrets['allium_query_id'], secrets['allium_api_key'])
         _update_tables(pool, tables, test_mode)
 
     elif update_from == "cryo":
+
+        raise NotImplementedError("sad")
         _update_tables(pool, tables, test_mode)
     else:
         raise NotImplementedError("Data puller not implimented")

--- a/v3/helpers/data_update.py
+++ b/v3/helpers/data_update.py
@@ -1,7 +1,7 @@
 import polars as pl
 import os
 from datetime import date, timedelta, datetime, timezone
-from .connectors import *
+from .connectors import allium, gbq
 from .test_helpers import *
 from pathlib import Path
 
@@ -281,6 +281,10 @@ def update_tables(pool, update_from, tables=[], test_mode=False):
     if update_from == "gcp":
         assert not gcp_locked, "GCP could not be imported"
         pool.connector = gbq()
+        _update_tables(pool, tables, test_mode)
+
+    if update_from == "allium":
+        pool.connector = allium()
         _update_tables(pool, tables, test_mode)
 
     elif update_from == "cryo":

--- a/v3/helpers/data_update.py
+++ b/v3/helpers/data_update.py
@@ -280,7 +280,10 @@ def update_tables(pool, update_from, tables=[], test_mode=False):
         assert pool.tgt_max_rows <= 100_000, "Attempting to pull too many rows"
         
         main = str(Path(f"{pool.data_path}/..").resolve())
-        with open(f"{main}/secrets.json", "r") as f:
+        secrets = f"{main}/secrets.json"
+       
+        assert os.path.exists(secrets), "Please provide secrets.json for API keys"
+        with open(secrets, "r") as f:
             secrets = json.load(f)
 
         pool.connector = allium(secrets['allium_query_id'], secrets['allium_api_key'])

--- a/v3/helpers/data_update.py
+++ b/v3/helpers/data_update.py
@@ -278,19 +278,18 @@ def update_tables(pool, update_from, tables=[], test_mode=False):
 
     if update_from == "allium":
         assert pool.tgt_max_rows <= 100_000, "Attempting to pull too many rows"
-        
+
         main = str(Path(f"{pool.data_path}/..").resolve())
         secrets = f"{main}/secrets.json"
-       
+
         assert os.path.exists(secrets), "Please provide secrets.json for API keys"
         with open(secrets, "r") as f:
             secrets = json.load(f)
 
-        pool.connector = allium(secrets['allium_query_id'], secrets['allium_api_key'])
+        pool.connector = allium(secrets["allium_query_id"], secrets["allium_api_key"])
         _update_tables(pool, tables, test_mode)
 
     elif update_from == "cryo":
-
         raise NotImplementedError("sad")
         _update_tables(pool, tables, test_mode)
     else:

--- a/v3/state.py
+++ b/v3/state.py
@@ -14,7 +14,7 @@ class v3Pool:
         low_memory=False,
         update=False,
         pull=True,
-        tgt_max_rows=1_000_000,
+        tgt_max_rows=100_000,
         test_mode=False,
     ):
         """


### PR DESCRIPTION
# Pending Discussions

## chain names
need help to confirm if the following are correct... Wanna add any other chain? Do chain names match the pattern you use internally??
```
        # which chains are layer 2s (to get the l1 fee)
        layer_2s = ["base", "arbitrum", "optimism"]
        
        # translate uniswap chain names to allium chain names
        uniswap_to_allium_name_mapping = {
            "ethereum": "ethereum",
            "base": "base",
            "arbitrum": "arbitrum",
            "optimism": "optimism",
            "polygon": "polygon",
        }
```

## passing allium credentials
we need to find the best way to pass the allium credentials to our connector
- option 1: env variables
- option 2: have a .json or .yaml or .env file
- option 3: pass it in the code

for now, I didn't implement any of these approaches, I hardcoded the credentials on the code just to test it out (but replaced it with empty strings before pushing the code to github)

## row limit
we limited the max number of rows to be fetched during a single execute() call to 100k rows. Is it fine?

# Usage Example

note: we still need to agree on a way to pass the allium credentials
```
from v3 import state
import datetime

pool = state.v3Pool('0x1d42064fc4beb5f8aaf85f4617ae8b3b5b8bd801', 'ethereum', update=True, update_from='allium')

starting = datetime.datetime(year = 2023, month = 11, day = 1)

priceEth = pool.getPriceSeries(starting)
```

# Caveats
- Allium is updating the dex schemas to simplify and optimize the queries used in this PR. Expect a future PR with simpler queries
