### PR TITLE
Add friendly typecasts when reading swap events and mint/burn requests

### DIFF
--- a/v3/README.md
+++ b/v3/README.md
@@ -23,7 +23,6 @@ The function `readFromMemoryOrDisk` intakes a parquet (as components of a filepa
 |       l1_fee      | i64             |
 
 **Mint & Burn**
-
 | Column            | Polars datatype |
 |-------------------|-----------------|
 |     chain_name    | str             |

--- a/v3/README.md
+++ b/v3/README.md
@@ -1,0 +1,47 @@
+The function `readFromMemoryOrDisk` intakes a parquet (as components of a filepath) and outputs a Polars dataframe. After running the function, here is the schema for `pool_mint_burn_events` and `pool_swap_events` dataframes.
+
+**Swaps**
+| Column            | Polars datatype |
+|-------------------|-----------------|
+|     chain_name    | str             |
+|      address      | str             |
+|  block_timestamp  | datetime[MiS]   |
+|    block_number   | i64             |
+|  transaction_hash | str             |
+|       sender      | str             |
+|     recipient     | str             |
+|      amount0      | f64             |
+|      amount1      | f64             |
+|    sqrtPriceX96   | f64             |
+|     liquidity     | f64             |
+|        tick       | i32             |
+|    from_address   | str             |
+|     to_address    | str             |
+| transaction_index | i64             |
+|     gas_price     | i64             |
+|      gas_used     | i64             |
+|       l1_fee      | i64             |
+
+**Mint & Burn**
+
+| Column            | Polars datatype |
+|-------------------|-----------------|
+|     chain_name    | str             |
+|      address      | str             |
+|  block_timestamp  | datetime[us]    |
+|    block_number   | i64             |
+|  transaction_hash | str             |
+|     log_index     | i64             |
+|       amount      | f64             |
+|      amount0      | f64             |
+|      amount1      | f64             |
+|       owner       | str             |
+|     tick_lower    | i64             |
+|     tick_upper    | i64             |
+|   type_of_event   | f64             |
+|     to_address    | str             |
+|    from_address   | str             |
+| transaction_index | i64             |
+|     gas_price     | i64             |
+|      gas_used     | i64             |
+|       l1_fee      | i64             |

--- a/v3/state.py
+++ b/v3/state.py
@@ -138,10 +138,10 @@ class v3Pool:
                             "amount1":pl.Float64,
                             "sqrtPriceX96":pl.Float64,
                             "liquidity":pl.Float64,
-                            "tick":pl.Float64,
-                            "gas_price":pl.Float64,
-                            "gas_used":pl.Float64,
-                            "l1_fee":pl.Float64
+                            "tick":pl.Int32, # tick in v3 is int24
+                            "gas_price":pl.Int64,
+                            "gas_used":pl.Int64,
+                            "l1_fee":pl.Int64
                         }
                     )
                     .collect()
@@ -172,10 +172,9 @@ class v3Pool:
                             "block_timestamp":pl.Datetime,
                             "amount0":pl.Float64,
                             "amount1":pl.Float64,
-                            "sqrtPriceX96":pl.Float64,
-                            "gas_price":pl.Float64,
-                            "gas_used":pl.Float64,
-                            "l1_fee":pl.Float64
+                            "gas_price":pl.Int64,
+                            "gas_used":pl.Int64,
+                            "l1_fee":pl.Int64
                         }
                     )
                     .with_columns(

--- a/v3/state.py
+++ b/v3/state.py
@@ -131,6 +131,19 @@ class v3Pool:
                     .with_columns(
                         as_of=pl.col("block_number") + pl.col("transaction_index") / 1e4
                     )
+                    .cast(
+                        {
+                            "block_timestamp":pl.Datetime,
+                            "amount0":pl.Float64,
+                            "amount1":pl.Float64,
+                            "sqrtPriceX96":pl.Float64,
+                            "liquidity":pl.Float64,
+                            "tick":pl.Float64,
+                            "gas_price":pl.Float64,
+                            "gas_used":pl.Float64,
+                            "l1_fee":pl.Float64
+                        }
+                    )
                     .collect()
                     .sort("as_of")
                 )
@@ -156,6 +169,13 @@ class v3Pool:
                             "tick_lower": pl.Int64,
                             "tick_upper": pl.Int64,
                             "type_of_event": pl.Float64,
+                            "block_timestamp":pl.Datetime,
+                            "amount0":pl.Float64,
+                            "amount1":pl.Float64,
+                            "sqrtPriceX96":pl.Float64,
+                            "gas_price":pl.Float64,
+                            "gas_used":pl.Float64,
+                            "l1_fee":pl.Float64
                         }
                     )
                     .with_columns(


### PR DESCRIPTION
Adding some basic typecasts for user friendliness and to head off unintended errors when reading and using data.