### PR TITLE
feat: pull only one pool

### DIFF
--- a/v3/helpers/connectors/allium.py
+++ b/v3/helpers/connectors/allium.py
@@ -215,8 +215,8 @@ class allium:
 
         data = response_json.get("data")
 
-        # if not data:
-        #     raise Exception(f"No data returned from Allium query {q}, query response: {response_json}")
+        if not data:
+            raise Exception(f"No data returned from Allium query {q}, query response: {response_json}")
 
         # polars from dict
         df = pl.DataFrame(data)

--- a/v3/helpers/connectors/gbq.py
+++ b/v3/helpers/connectors/gbq.py
@@ -2,13 +2,16 @@ import polars as pl
 import os
 from datetime import date, timedelta, datetime, timezone
 
+
 def get_gbq_client(proj_id):
     try:
         from google.cloud import bigquery
 
         return bigquery.Client(project=proj_id)
     except ImportError:
-        raise Exception("GCP could not be imported. If you want to use another source (such as allium), set update_from to the desired source e.g. 'allium'")
+        raise Exception(
+            "GCP could not be imported. If you want to use another source (such as allium), set update_from to the desired source e.g. 'allium'"
+        )
 
 
 class gbq:

--- a/v3/state.py
+++ b/v3/state.py
@@ -56,9 +56,9 @@ class v3Pool:
         # and "uniswap_v3_pool" bc its unneeded
         self.tables = [
             "factory_pool_created",
+            "pool_initialize_events",
             "pool_swap_events",
             "pool_mint_burn_events",
-            "pool_initialize_events",
         ]
 
         self.connector = None


### PR DESCRIPTION
the first data pull for pools takes forever, because it pulls data for all pools. many users only want to follow one pool, so they spend a lot of time pulling data they don't care about.

this PR changes data pulling for all pools to only one.