### PR TITLE
Package pip installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ cython_debug/
 #.idea/
 
 !Crosschain_Liquidity_GIF.ipynb
+
+.DS_Store

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="v3_polars",
+    version="0.1",
+    packages=find_packages(),
+    install_requires=[
+        "polars",
+    ],
+)


### PR DESCRIPTION
By adding a simple `setup.py` to the root of the repo, we can now easily install the repo into one's virtual env with `pip install -e .` that allows for simple use of the library in other repos as well by importing from this repo as a package, e.g.:

```python
from v3.state import v3Pool

address = "0x448a70a160d6be76ec6cdf3a7ed9988d3eeebcd2"
eth = v3Pool(
    address,
    "ethereum",
    update=True,
    update_from="allium",
)
```